### PR TITLE
refactor: restructure flake architecture and eliminate code duplication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
         echo "  - wiringop (GPIO library)"
         echo ""
         
-        nix build .#boards-orangepi6plus-tools-cross \
+        nix build .#orangepi6plus-tools-cross \
           --print-build-logs \
           --fallback
 
@@ -226,7 +226,7 @@ jobs:
     
     - name: Build SD Card Image (Orange Pi 6 Plus)
       run: |
-        nix build .#boards-orangepi6plus-sdImage-cross \
+        nix build .#orangepi6plus-sdImage-cross \
           --print-build-logs \
           --fallback \
           --keep-going
@@ -284,7 +284,7 @@ jobs:
     
     - name: Build Netboot Package (Orange Pi 6 Plus)
       run: |
-        nix build .#boards-orangepi6plus-netboot-cross \
+        nix build .#orangepi6plus-netboot-cross \
           --print-build-logs \
           --fallback \
           --keep-going

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NixOS for CIX CD8180/CD8160 SoC (Sky1)
 
 [![Build NixOS Images](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/build.yml/badge.svg)](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/build.yml)
-[![Auto Update Dependencies](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/auto-update.yml/badge.svg)](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/auto-update.yml)
+[![Auto Update Dependencies](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/auto-update.yml/badge.svg)](https://github.com/i-am-logger/nixos-cix-cd8180/actions/workflows/auto-update.yml)  
 [![Cachix Cache](https://img.shields.io/badge/cachix-i--am--logger-blue.svg)](https://i-am-logger.cachix.org)
 [![NixOS Unstable](https://img.shields.io/badge/NixOS-unstable-blue.svg)](https://nixos.org)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
@@ -10,99 +10,26 @@
 
 > ⚠️ Work in progress, use at your own risk...
 
-NixOS flake for CIX CD8180/CD8160 (Sky1) based SBCs. Includes vendor kernel and proprietary drivers.
+NixOS flake for CIX CD8180/CD8160 (Sky1) based single-board computers.
 
-**Kernel**: Vendor kernel from orangepi-xunlong
+- **Kernel**: Linux 6.6.89-sky1 (vendor)
+- **Drivers**: GPU, NPU, ISP, VPU (proprietary)
+- **Firmware**: Pre-packaged for all hardware
+- **Tools**: Board-specific configuration utilities
 
-## Boards
+## Supported Boards
 
-UEFI Boot Support:
+| Board | SD Card | NVMe | PXE | Documentation |
+|-------|---------|------|-----|---------------|
+| Orange Pi 6 Plus | ✅ Building | ⚠️ Untested | ✅ Building | [docs](docs/boards/orangepi-6-plus.md) |
+| Radxa Orion O6 | ⚠️ Planned | ⚠️ Planned | ⚠️ Planned | - |
 
-| Single Board Computer | Boot from SD card  | Boot from NVMe SSD | Network Boot (PXE) |
-| --------------------- | ------------------ | ------------------ | ------------------ |
-| Orange Pi 6 Plus      | ✅ Building        | ⚠️ Untested        | ✅ Building        |
-| Radxa Orion O6        | ⚠️ Planned         | ⚠️ Planned         | ⚠️ Planned         |
+## Documentation
 
-All boards use the CIX CD8180/CD8160 SoC base configuration (`modules/soc/sky1.nix`) which includes kernel drivers and firmware. Board-specific modules only contain board-specific settings (console ports, GPIO tools, etc).
-
-## Hardware Support Status (CIX CD8180/CD8160 SoC)
-
-| Component | Kernel Space | User Space | Status |
-|-----------|--------------|------------|--------|
-| **Ethernet** (RTL8126 2.5GbE) | ✅ r8169 (in-tree) | - | Working |
-| **M.2 NVMe SSD** | ✅ nvme (in-tree) | - | Working |
-| **USB 3.0/2.0** | ✅ xhci_pci (in-tree) | - | Working |
-| **UEFI Boot** | ✅ Vendor firmware | - | Working |
-| **GPU** (Mali-G610 MP4) | ✅ mali-gpu.ko (opensource) | ✅ cix-gpu-umd (proprietary) | Packaged, untested |
-| **NPU** (28.8 TOPS) | ✅ aipu.ko (opensource) | ✅ cix-npu-umd (proprietary) | Packaged, untested |
-| **ISP** (Camera) | ✅ armcb-isp.ko (opensource) | ✅ cix-isp-umd (proprietary) | Packaged, untested |
-| **VPU** (Video codec) | ✅ mvx-vpu.ko (opensource) | ✅ Firmware (proprietary) | Packaged, untested |
-| **WiFi/Bluetooth** | N/A (not on board) | ✅ Firmware (for USB dongles) | Packaged, untested |
-| **Audio** | ✅ In-tree | - | Untested |
-| **GPIO** | ✅ sysfs, cdev (in-tree) | - | Working |
-| **I3C** | ✅ In-tree | ✅ i3ctransfer (proprietary) | Packaged, untested |
-| **Power Management** | ✅ In-tree | ✅ pmtool (proprietary) | Packaged, untested |
-| **UART/Serial** | ✅ In-tree | - | Working |
-
-## Hardware Interface Tools
-
-**Included in base system:**
-- **I3C/Power**: `cix-tools` (i3ctransfer, pmtool) - Vendor-specific tools
-
-**Available via nixpkgs (add to configuration.nix):**
-- **I2C**: `i2c-tools` (i2cdetect, i2cget, i2cset, i2cdump, i2ctransfer)
-- **SPI**: `spi-tools` (spidev_test, spidev_fdx)
-- **MTD/Flash**: `mtdutils` (mtd_debug, flash_erase, nandwrite, etc.)
-- **UART/Serial**: `minicom`, `picocom`, `screen`
-
-## Orange Pi 6 Plus Board Tools
-
-- [x] orangepi-config - hardware configuration tool
-- [x] wiringop - GPIO library and utilities
-
-## Installation
-
-See [docs/installation.md](docs/installation.md) for detailed instructions on:
-- SD Card Boot
-- NVMe SSD installation  
-- Network Boot (PXE)
-
-## Usage
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
-  };
-
-  outputs = { nixpkgs, nixos-cix-cd8180, ... }: {
-    nixosConfigurations.orangepi6plus = nixpkgs.lib.nixosSystem {
-      system = "aarch64-linux";
-      modules = [
-        nixos-cix-cd8180.nixosModules.boards.orangepi6plus
-        ./configuration.nix
-      ];
-    };
-  };
-}
-```
-
-### Using NixOS Stable
-
-To use a stable NixOS release instead of unstable:
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";  # or nixos-25.05
-    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
-  };
-  # ... rest of config
-}
-```
-
-Example configurations: [examples/](./examples/)
+- **[CIX CD8180/CD8160 SoC](docs/cix-cd8180-cd8160.md)** - Kernel, drivers, firmware, hardware specs
+- **[Installation Guide](docs/installation.md)** - SD Card, NVMe, Network Boot
+- **[Development Guide](docs/development.md)** - Building, testing, CI/CD
+- **[Example Configurations](examples/)** - Minimal, desktop, AI/ML workstation
 
 ## Vendor Repositories
 
@@ -123,17 +50,13 @@ Thanks to the [NixOS on ARM Matrix group](https://matrix.to/#/#nixos-on-arm:nixo
 
 ## Development
 
-See [docs/development.md](docs/development.md) for:
-- Building locally with ccache
-- Development commands
-- Code quality checks
-- Testing procedures
-- Troubleshooting
+See [Development Guide](docs/development.md) for building, testing, and contributing.
 
-**Quick start:**
+Quick start:
 ```bash
-# Build with ccache (first build ~35-40 min, subsequent builds much faster)
-nix build .#boards-orangepi6plus-sdImage-cross --print-build-logs
+nix flake check  # Validate flake
+nix flake show   # Show available packages
+nix develop      # Enter development shell
 ```
 
 ## Contributing

--- a/devshells.nix
+++ b/devshells.nix
@@ -1,0 +1,50 @@
+# Development shells for NixOS CIX CD8180/CD8160
+{ pkgs, pkgsCrossUnfree }:
+
+{
+  default = pkgs.mkShell {
+    name = "nixos-cix-cd8180-dev";
+    packages = with pkgs; [
+      git
+      cachix
+      nix-prefetch-github
+      nixpkgs-fmt
+    ];
+    shellHook = ''
+      echo "NixOS CIX CD8180/CD8160 (Sky1) Development Environment"
+      echo ""
+      echo "Available commands:"
+      echo "  nix flake check       - Check flake"
+      echo "  nixpkgs-fmt --check . - Check formatting"
+      echo "  nixpkgs-fmt .         - Format all .nix files"
+      echo "  nix build .#sdImage   - Build SD image"
+      echo "  cachix push           - Push to cache"
+    '';
+  };
+
+  kernel = pkgs.mkShell {
+    name = "kernel-build-env";
+    packages = with pkgs; [
+      pkg-config
+      ncurses
+      pkgsCrossUnfree.stdenv.cc
+      gcc
+      bc
+      bison
+      flex
+      openssl
+      perl
+      python3
+      dtc
+    ] ++ pkgs.linux.nativeBuildInputs;
+
+    shellHook = ''
+      export CROSS_COMPILE=aarch64-unknown-linux-gnu-
+      export ARCH=arm64
+      export PKG_CONFIG_PATH="${pkgs.ncurses.dev}/lib/pkgconfig:"
+      echo "Kernel development environment for CIX CD8180/CD8160"
+      echo "ARCH=$ARCH"
+      echo "CROSS_COMPILE=$CROSS_COMPILE"
+    '';
+  };
+}

--- a/docs/boards/orangepi-6-plus.md
+++ b/docs/boards/orangepi-6-plus.md
@@ -1,0 +1,271 @@
+# Orange Pi 6 Plus
+
+Board-specific documentation for Orange Pi 6 Plus (CIX CD8180/CD8160 SoC).
+
+**SoC Documentation**: See [CIX CD8180/CD8160](../cix-cd8180-cd8160.md) for kernel, drivers, firmware, and hardware specifications.
+
+## Quick Start
+
+**Build SD Card Image:**
+```bash
+# Cross-compile from x86_64 (recommended, first build ~35-40 min)
+nix build .#orangepi6plus-sdImage-cross --print-build-logs
+
+# Native build on aarch64
+nix build .#orangepi6plus-sdImage --print-build-logs
+```
+
+**Flash to SD Card:**
+```bash
+zstd -d result/sd-image/*.img.zst
+sudo dd if=result/sd-image/*.img of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+See [Installation Methods](#installation-methods) below for NVMe and Network Boot options.
+
+---
+
+## Board Overview
+
+- **SoC**: CIX CD8180/CD8160 (Sky1)
+- **RAM**: 4GB / 8GB / 16GB LPDDR5
+- **Storage**: MicroSD, NVMe M.2 2280
+- **Network**: Realtek RTL8126 2.5GbE
+- **USB**: 1x USB 3.0, 2x USB 2.0
+- **Video**: HDMI 2.1 (4K@60Hz)
+- **GPIO**: 40-pin header
+- **Power**: USB-C PD, 5V/4A
+- **Boot**: UEFI firmware (pre-installed)
+
+## Board-Specific Components
+
+### SD Card Image
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#orangepi6plus-sdImage-cross
+
+# Native build on aarch64
+nix build .#orangepi6plus-sdImage
+
+# With build logs
+nix build .#orangepi6plus-sdImage-cross --print-build-logs
+```
+
+**Output**: `result/sd-image/nixos-sd-image-*.img.zst`
+
+### Network Boot (Netboot)
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#orangepi6plus-netboot-cross
+
+# Native build on aarch64
+nix build .#orangepi6plus-netboot
+
+# With build logs
+nix build .#orangepi6plus-netboot-cross --print-build-logs
+```
+
+**Output**: `result/{kernel,initrd,netboot.ipxe}`
+
+### Board Tools
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#orangepi6plus-tools-cross
+
+# Native build on aarch64
+nix build .#orangepi6plus-tools
+```
+
+**Included Tools:**
+- `orangepi-config` - Hardware configuration utility
+- `wiringop` - GPIO library and utilities
+
+## Installation Methods
+
+### Method 1: SD Card Boot
+
+See [Installation Guide - SD Card](../installation.md#option-1-sd-card-boot) for detailed steps.
+
+**Quick Start:**
+
+```bash
+# Build image
+nix build .#orangepi6plus-sdImage-cross
+
+# Flash to SD card
+zstd -d result/sd-image/*.img.zst
+sudo dd if=result/sd-image/*.img of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+### Method 2: NVMe SSD Boot
+
+See [Installation Guide - NVMe](../installation.md#option-2-boot-from-nvme-ssd) for detailed steps.
+
+**Requirements:**
+- Initial SD card boot
+- NVMe M.2 SSD installed
+- UEFI firmware (pre-installed)
+
+### Method 3: Network Boot (PXE)
+
+See [Installation Guide - Netboot](../installation.md#option-3-network-boot-pxe) for detailed steps.
+
+**Quick Start:**
+
+```bash
+# Build netboot package
+nix build .#orangepi6plus-netboot-cross
+
+# Copy to PXE server
+cp result/kernel /srv/tftp/nixos-cix-cd8180/kernel
+cp result/initrd /srv/tftp/nixos-cix-cd8180/initrd
+cp result/netboot.ipxe /srv/tftp/nixos-cix-cd8180/boot.ipxe
+```
+
+## Board Configuration
+
+### Using in Your Flake
+
+**With NixOS Unstable** (recommended):
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
+  };
+
+  outputs = { nixpkgs, nixos-cix-cd8180, ... }: {
+    nixosConfigurations.orangepi6plus = nixpkgs.lib.nixosSystem {
+      system = "aarch64-linux";
+      modules = [
+        nixos-cix-cd8180.nixosModules.orangepi6plus
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+**With NixOS Stable:**
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";  # or nixos-25.05
+    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
+  };
+  # ... same outputs as above
+}
+```
+
+The board module automatically includes:
+- CIX CD8180/CD8160 SoC base configuration
+- Vendor kernel (Linux 6.6.89-sky1) with all hardware drivers
+- Board-specific tools (orangepi-config, wiringop)
+- Firmware packages
+
+
+
+## Hardware Status
+
+### Working ✅
+- **Ethernet**: RTL8126 2.5GbE (r8169 driver)
+- **NVMe**: M.2 SSD support (nvme driver)
+- **USB**: USB 3.0/2.0 ports (xhci_pci driver)
+- **UART/Serial**: Console access
+- **GPIO**: sysfs, cdev access
+- **UEFI Boot**: From SD card and NVMe
+
+### Untested ⚠️
+- **GPU**: Mali-G610 MP4 (drivers packaged)
+- **NPU**: 28.8 TOPS (drivers packaged)
+- **ISP**: Camera support (drivers packaged)
+- **VPU**: Video codec (drivers packaged)
+- **Audio**: HDMI audio, analog audio
+- **WiFi/Bluetooth**: USB dongles (firmware packaged)
+
+## Example Configurations
+
+See [examples/](../../examples/) for generic configurations that work with any CIX CD8180/CD8160 board:
+
+- **[minimal.nix](../../examples/minimal.nix)** - Headless server
+- **[desktop.nix](../../examples/desktop.nix)** - XFCE desktop environment
+- **[ai-workstation.nix](../../examples/ai-workstation.nix)** - ML/AI development with NPU
+
+All examples include a board module selector - just uncomment your board.
+
+## Troubleshooting
+
+### Board won't boot from SD card
+
+1. Verify UEFI firmware is installed (pre-installed on Orange Pi 6 Plus)
+2. Check SD card is properly flashed: `sudo fdisk -l /dev/sdX`
+3. Try a different SD card (some cards are incompatible)
+4. Check UEFI boot menu (ESC or F12 during boot)
+
+### No NVMe drive detected
+
+1. Check M.2 SSD is properly seated
+2. Verify NVMe support in UEFI settings
+3. Check kernel messages: `dmesg | grep nvme`
+4. Ensure NVMe is detected: `lsblk`
+
+### Network boot fails
+
+1. Verify DHCP server is responding
+2. Check TFTP/HTTP server is accessible
+3. Review UEFI network settings
+4. Check firewall rules on PXE server
+5. Verify iPXE script syntax
+
+### No display output
+
+1. Check HDMI cable connection
+2. Try a different HDMI port/cable
+3. Check monitor input selection
+4. Verify GPU drivers are loaded (requires vendor kernel)
+5. Check kernel logs: `dmesg | grep -i hdmi`
+
+## GPIO Access
+
+### Using Board Tools
+
+```bash
+# Install wiringop
+nix-shell -p wiringop
+
+# GPIO utilities
+gpio readall      # Show GPIO status
+gpio mode 1 out   # Set pin to output
+gpio write 1 1    # Write high
+gpio read 1       # Read pin state
+```
+
+### Sysfs Access
+
+```bash
+# Export GPIO
+echo 510 > /sys/class/gpio/export
+
+# Set direction
+echo out > /sys/class/gpio/gpio510/direction
+
+# Write value
+echo 1 > /sys/class/gpio/gpio510/value
+```
+
+## References
+
+- [CIX CD8180/CD8160 SoC Documentation](../cix-cd8180-cd8160.md) - Kernel, drivers, firmware
+- [Installation Guide](../installation.md) - Detailed installation instructions
+- [Development Guide](../development.md) - Building and development
+- [Main README](../../README.md) - Project overview
+- [Orange Pi 6 Plus Official Page](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-6-Plus.html)

--- a/docs/cix-cd8180-cd8160.md
+++ b/docs/cix-cd8180-cd8160.md
@@ -1,0 +1,272 @@
+# CIX CD8180/CD8160 SoC
+
+SoC-level documentation for CIX CD8180/CD8160 (codename: Sky1).
+
+## Overview
+
+- **CPU**: ARM Cortex-A76 + Cortex-A55 (big.LITTLE)
+- **GPU**: Mali-G610 MP4
+- **NPU**: 28.8 TOPS AIPU
+- **ISP**: ARM Camera Block
+- **VPU**: MVX Video (H.264/H.265, 4K@60fps)
+
+## Components
+
+### Kernel
+
+**Vendor Kernel**: Linux 6.6.89-sky1 from orangepi-xunlong
+
+**Features:**
+- Complete hardware support for CD8180/CD8160
+- Mali-G610 MP4 GPU drivers
+- 28.8 TOPS NPU (AIPU) drivers  
+- ISP (Image Signal Processor) drivers
+- VPU (Video Processing Unit) drivers
+- Device trees for all CD8180/CD8160 boards
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#kernel-cross
+
+# Native build on aarch64
+nix build .#kernel
+
+# With build logs (shows ccache stats)
+nix build .#kernel-cross --print-build-logs
+
+# Check kernel version
+nix eval .#kernel-cross.version
+```
+
+**Documentation**: [pkgs/kernel/README.md](../pkgs/kernel/README.md)
+
+### Drivers
+
+**Kernel Modules**: GPU, NPU, ISP, VPU
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#drivers-cross
+
+# Native build on aarch64
+nix build .#drivers
+
+# With build logs
+nix build .#drivers-cross --print-build-logs
+```
+
+**Included Drivers:**
+
+| Driver | Package | License | Status |
+|--------|---------|---------|--------|
+| Mali-G610 MP4 GPU | `cix-gpu-umd` | Proprietary | Packaged, untested |
+| 28.8 TOPS NPU | `cix-npu-umd` | Proprietary | Packaged, untested |
+| ISP (Camera) | `cix-isp-umd` | Proprietary | Packaged, untested |
+| VPU (Video) | `cix-vpu-firmware` | Proprietary | Packaged, untested |
+
+**Documentation**: [pkgs/drivers/README.md](../pkgs/drivers/README.md)
+
+### Firmware
+
+**System Firmware**: GPU, NPU, ISP, VPU, WiFi, Bluetooth
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#firmware-cross
+
+# Native build on aarch64
+nix build .#firmware
+```
+
+**Package**: `cix-firmware` (proprietary)
+
+### SoC Tools
+
+**CIX Tools**: I3C and Power Management utilities
+
+**Build Commands:**
+
+```bash
+# Cross-compile from x86_64 (recommended)
+nix build .#tools-cross
+
+# Native build on aarch64
+nix build .#tools
+```
+
+**Included Tools:**
+- `i3ctransfer` - I3C bus communication utility
+- `pmtool` - Power management utility
+
+**Package**: `cix-tools` (proprietary)
+
+## Hardware Support Status
+
+| Component | Kernel Space | User Space | Status |
+|-----------|--------------|------------|--------|
+| **GPU** (Mali-G610 MP4) | ✅ mali-gpu.ko | ✅ cix-gpu-umd | Packaged, untested |
+| **NPU** (28.8 TOPS) | ✅ aipu.ko | ✅ cix-npu-umd | Packaged, untested |
+| **ISP** (Camera) | ✅ armcb-isp.ko | ✅ cix-isp-umd | Packaged, untested |
+| **VPU** (Video codec) | ✅ mvx-vpu.ko | ✅ Firmware | Packaged, untested |
+| **I3C** | ✅ In-tree | ✅ i3ctransfer | Packaged, untested |
+| **Power Management** | ✅ In-tree | ✅ pmtool | Packaged, untested |
+| **Ethernet** | ✅ In-tree (board-specific) | - | Working on boards |
+| **NVMe** | ✅ nvme (in-tree) | - | Working on boards |
+| **USB** | ✅ xhci_pci (in-tree) | - | Working on boards |
+
+## Using SoC Components
+
+### In Your NixOS Configuration
+
+The SoC drivers and firmware are automatically included when you import a board module:
+
+```nix
+{
+  imports = [ nixos-cix-cd8180.nixosModules.orangepi6plus ];
+}
+```
+
+The board module includes the SoC base configuration which provides:
+- Vendor kernel with all hardware drivers
+- Kernel modules (GPU, NPU, ISP, VPU)
+- Firmware packages
+- SoC tools (i3ctransfer, pmtool)
+
+### Kernel Selection
+
+**Default**: Vendor kernel (recommended for full hardware support)
+
+```nix
+# This is set automatically by board modules
+boot.kernelPackages = pkgs.cixSky1VendorKernelPackages;
+```
+
+**Override with Mainline**:
+
+```nix
+{
+  # Use mainline kernel (some hardware may not work)
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+}
+```
+
+**Note**: Mainline kernels lack GPU/NPU/ISP/VPU drivers.
+
+### Adding SoC Packages
+
+Drivers and tools are included by default in board configurations. For custom setups:
+
+```nix
+{
+  environment.systemPackages = with pkgs; [
+    cix-tools       # i3ctransfer, pmtool
+    cix-firmware    # Firmware files
+    # Drivers are kernel modules, loaded automatically
+  ];
+}
+```
+
+## Boards Using This SoC
+
+| Board | Status | Documentation |
+|-------|--------|---------------|
+| Orange Pi 6 Plus | ✅ Building | [Board Guide](boards/orangepi-6-plus.md) |
+| Radxa Orion O6 | ⚠️ Planned | N/A |
+
+## Development
+
+### Building Locally
+
+```bash
+# Build all SoC components (cross-compiled)
+nix build .#kernel-cross
+nix build .#drivers-cross
+nix build .#firmware-cross
+nix build .#tools-cross
+
+# Enter development shell
+nix develop           # General development
+nix develop .#kernel  # Kernel-specific with cross-compile tools
+```
+
+### ccache for Kernel Builds
+
+ccache is enabled by default for kernel builds:
+
+- **First build**: ~35-40 minutes (populates ccache)
+- **Incremental builds**: Much faster with ccache hits
+- **Cache location**: `/tmp/ccache` (10 GB max)
+- **Cache stats**: Shown in build logs (postBuild phase)
+
+### Vendor Resources
+
+- **Kernel Source**: [orangepi-xunlong/linux-orangepi](https://github.com/orangepi-xunlong/linux-orangepi) (branch: `orange-pi-6.1-cix`)
+- **Drivers/Firmware**: [orangepi-xunlong/component_cix-current](https://github.com/orangepi-xunlong/component_cix-current)
+- **Build System**: [orangepi-xunlong/orangepi-build](https://github.com/orangepi-xunlong/orangepi-build)
+
+## Technical Specifications
+
+### CPU Architecture
+
+- **Big Cores**: ARM Cortex-A76 (high performance)
+- **Little Cores**: ARM Cortex-A55 (power efficiency)
+- **Architecture**: ARMv8.2-A (64-bit)
+- **ISA**: AArch64
+
+### GPU
+
+- **Model**: ARM Mali-G610 MP4
+- **API Support**: OpenGL ES 3.2, Vulkan 1.2, OpenCL 2.2
+- **Cores**: 4 shader cores
+
+### NPU
+
+- **Performance**: 28.8 TOPS (INT8)
+- **Type**: ARM China Zhouyi AIPU
+- **Precision**: INT8, INT16, FP16 support
+
+### ISP
+
+- **Type**: ARM Camera Block ISP
+- **Support**: RAW sensor input, image processing pipeline
+
+### VPU
+
+- **Type**: MVX Video Processing Unit
+- **Codecs**: H.264, H.265/HEVC hardware encode/decode
+- **Resolution**: Up to 4K@60fps
+
+## Package Structure
+
+```
+pkgs/
+├── kernel/          # Vendor and mainline kernel packages
+│   ├── vendor.nix   # 6.6.89-sky1 (recommended)
+│   └── mainline.nix # Future mainline support
+├── drivers/         # Proprietary drivers
+│   ├── gpu/         # Mali-G610 MP4
+│   ├── npu/         # 28.8 TOPS AIPU
+│   ├── isp/         # Camera ISP
+│   └── vpu/         # Video codec
+├── firmware/        # System firmware
+└── cix-tools/       # I3C, power management tools
+
+modules/
+└── soc/
+    └── sky1.nix     # Base SoC configuration
+```
+
+## References
+
+- [Main README](../README.md) - Project overview
+- [Installation Guide](installation.md) - Installing NixOS
+- [Development Guide](development.md) - Building and testing
+- [Kernel README](../pkgs/kernel/README.md) - Kernel details
+- [Drivers README](../pkgs/drivers/README.md) - Driver details
+- [Orange Pi 6 Plus Board Guide](boards/orangepi-6-plus.md) - Board-specific documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,12 +18,12 @@ Build an image, flash to SD card, and boot.
 
 **Cross-compile from x86_64** (recommended):
 ```bash
-nix build .#boards-orangepi6plus-sdImage-cross
+nix build .#orangepi6plus-sdImage-cross
 ```
 
 **Native build on aarch64**:
 ```bash
-nix build .#boards-orangepi6plus-sdImage
+nix build .#orangepi6plus-sdImage
 ```
 
 The image will be in `result/sd-image/nixos-image-*.img.zst`
@@ -117,9 +117,14 @@ Boot over the network without local storage.
 
 #### 1. Build Netboot Components
 
+**Cross-compile from x86_64** (recommended):
 ```bash
-# Build all netboot components in one package
-nix build .#boards-orangepi6plus-netboot
+nix build .#orangepi6plus-netboot-cross
+```
+
+**Native build on aarch64**:
+```bash
+nix build .#orangepi6plus-netboot
 ```
 
 This creates a single package with:
@@ -187,25 +192,9 @@ dhcp-boot=tag:efi-arm64,nixos-cix-cd8180/boot.ipxe
 
 ## Post-Installation
 
-See [examples/](../examples/) for configuration examples.
+For configuration examples, see your board's documentation.
 
 ## Troubleshooting
 
-### Board won't boot from SD card
-
-1. Verify UEFI firmware is installed (pre-installed on Orange Pi 6 Plus)
-2. Check SD card is properly flashed: `sudo fdisk -l /dev/sdX`
-3. Try a different SD card
-
-### Can't find NVMe drive
-
-1. Check M.2 slot is properly seated
-2. Verify NVMe support in UEFI settings
-3. Check `dmesg | grep nvme` for kernel messages
-
-### Network boot fails
-
-1. Verify DHCP server is responding
-2. Check TFTP/HTTP server is accessible
-3. Review UEFI network settings
-4. Check firewall rules on PXE server
+For board-specific troubleshooting, see your board's documentation:
+- [Orange Pi 6 Plus Troubleshooting](boards/orangepi-6-plus.md#troubleshooting)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,20 @@
 # Example Configurations
 
-This directory contains example NixOS configurations for the Orange Pi 6 Plus.
+Generic NixOS configurations for CIX CD8180/CD8160 based boards.
+
+## Choosing Your Board
+
+All examples work with any board using the CIX CD8180/CD8160 SoC. Import the board module:
+
+```nix
+{
+  imports = [ nixos-cix-cd8180.nixosModules.orangepi6plus ];
+}
+```
+
+**Available board modules:**
+- `nixosModules.orangepi6plus` - Orange Pi 6 Plus
+- `nixosModules.radxaoriono6` - Radxa Orion O6 (when available)
 
 ## Available Examples
 
@@ -14,11 +28,9 @@ Features:
 - Basic firewall
 - Single user account
 
-**Build**:
+**Build** (replace `orangepi6plus` with your board name):
 ```bash
-nix build .#boards-orangepi6plus-sdImage
-# or the long form:
-# nix build .#nixosConfigurations.orangepi6plus.config.system.build.sdImage
+nix build .#orangepi6plus-sdImage-cross
 ```
 
 ### 2. [desktop.nix](./desktop.nix) - Desktop Environment
@@ -81,12 +93,12 @@ cp examples/minimal.nix my-config/flake.nix
 
 3. Build:
 ```bash
-nix build .#boards-orangepi6plus-sdImage
+nix build .#orangepi6plus-sdImage
 ```
 
 ### Method 2: Import as Module
 
-Use the nixos-cix-cd8180 flake as an input and import the board module:
+Use the nixos-cix-cd8180 flake as an input:
 
 ```nix
 {
@@ -98,7 +110,7 @@ Use the nixos-cix-cd8180 flake as an input and import the board module:
   outputs = { nixpkgs, nixos-cix-cd8180, ... }: {
     nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
       modules = [
-        nixos-cix-cd8180.nixosModules.boards.orangepi6plus
+        nixos-cix-cd8180.nixosModules.orangepi6plus
         ./configuration.nix
       ];
     };
@@ -159,7 +171,7 @@ Before flashing to SD card:
 nix flake check
 
 # Build to verify
-nix build .#boards-orangepi6plus-sdImage --dry-run
+nix build .#orangepi6plus-sdImage --dry-run
 ```
 
 ## Common Issues

--- a/examples/ai-workstation.nix
+++ b/examples/ai-workstation.nix
@@ -1,19 +1,21 @@
-# AI/ML workstation configuration for Orange Pi 6 Plus
-# Optimized for NPU (28.8 TOPS) usage with machine learning frameworks
+# AI/ML workstation with NPU support
+# Works with any CIX CD8180/CD8160 based board (all have 28.8 TOPS NPU)
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixos-cix-cd8180.url = "github:logger/nixos-cix-cd8180";
+    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
   };
 
   outputs = { self, nixpkgs, nixos-cix-cd8180, ... }: {
-    nixosConfigurations.orangepi6plus = nixpkgs.lib.nixosSystem {
+    nixosConfigurations.ai-workstation = nixpkgs.lib.nixosSystem {
       system = "aarch64-linux";
       modules = [
-        nixos-cix-cd8180.nixosModules.boards.orangepi6plus
+        # Choose your board:
+        nixos-cix-cd8180.nixosModules.orangepi6plus
+        # nixos-cix-cd8180.nixosModules.radxaoriono6  # (when available)
 
         {
-          networking.hostName = "orangepi-ai";
+          networking.hostName = "ai-workstation";
 
           # Enable SSH for remote development
           services.openssh = {
@@ -104,10 +106,10 @@
       ];
     };
 
-    # Convenience packages for easier building
+    # Build: nix build .#sdImage or nix build .#netboot
     packages.aarch64-linux = {
-      default = self.nixosConfigurations.orangepi6plus.config.system.build.toplevel;
-      sdImage = self.nixosConfigurations.orangepi6plus.config.system.build.sdImage;
+      sdImage = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-sdImage;
+      netboot = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-netboot;
     };
   };
 }

--- a/examples/desktop.nix
+++ b/examples/desktop.nix
@@ -1,19 +1,21 @@
-# Desktop configuration with GPU acceleration for Orange Pi 6 Plus
-# Includes window manager and basic desktop applications
+# Desktop configuration with XFCE
+# Works with any CIX CD8180/CD8160 based board
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixos-cix-cd8180.url = "github:logger/nixos-cix-cd8180";
+    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
   };
 
   outputs = { self, nixpkgs, nixos-cix-cd8180, ... }: {
-    nixosConfigurations.orangepi6plus = nixpkgs.lib.nixosSystem {
+    nixosConfigurations.desktop = nixpkgs.lib.nixosSystem {
       system = "aarch64-linux";
       modules = [
-        nixos-cix-cd8180.nixosModules.boards.orangepi6plus
+        # Choose your board:
+        nixos-cix-cd8180.nixosModules.orangepi6plus
+        # nixos-cix-cd8180.nixosModules.radxaoriono6  # (when available)
 
         {
-          networking.hostName = "orangepi-desktop";
+          networking.hostName = "desktop";
 
           # Enable X11 and window manager
           services.xserver = {
@@ -67,10 +69,10 @@
       ];
     };
 
-    # Convenience packages for easier building
+    # Build: nix build .#sdImage or nix build .#netboot
     packages.aarch64-linux = {
-      default = self.nixosConfigurations.orangepi6plus.config.system.build.toplevel;
-      sdImage = self.nixosConfigurations.orangepi6plus.config.system.build.sdImage;
+      sdImage = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-sdImage;
+      netboot = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-netboot;
     };
   };
 }

--- a/examples/minimal.nix
+++ b/examples/minimal.nix
@@ -1,19 +1,21 @@
-# Minimal headless configuration for Orange Pi 6 Plus
+# Minimal headless configuration
+# Works with any CIX CD8180/CD8160 based board
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixos-cix-cd8180.url = "github:logger/nixos-cix-cd8180";
+    nixos-cix-cd8180.url = "github:i-am-logger/nixos-cix-cd8180";
   };
 
   outputs = { self, nixpkgs, nixos-cix-cd8180, ... }: {
-    nixosConfigurations.orangepi6plus = nixpkgs.lib.nixosSystem {
+    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
       system = "aarch64-linux";
       modules = [
-        # Board module (includes cix CD8180/CD8160 vendor kernel + drivers)
-        nixos-cix-cd8180.nixosModules.boards.orangepi6plus
+        # Choose your board:
+        nixos-cix-cd8180.nixosModules.orangepi6plus
+        # nixos-cix-cd8180.nixosModules.radxaoriono6  # (when available)
 
         {
-          networking.hostName = "orangepi";
+          networking.hostName = "nixos";
 
           services.openssh = {
             enable = true;
@@ -43,10 +45,10 @@
       ];
     };
 
-    # Convenience packages for easier building
+    # Build: nix build .#sdImage or nix build .#netboot
     packages.aarch64-linux = {
-      default = self.nixosConfigurations.orangepi6plus.config.system.build.toplevel;
-      sdImage = self.nixosConfigurations.orangepi6plus.config.system.build.sdImage;
+      sdImage = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-sdImage;
+      netboot = nixos-cix-cd8180.packages.aarch64-linux.orangepi6plus-netboot;
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -18,42 +18,6 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1764234087,
-        "narHash": "sha256-NHF7QWa0ZPT8hsJrvijREW3+nifmF2rTXgS2v0tpcEA=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "032a1878682fafe829edfcf5fdfad635a2efe748",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1766902085,
@@ -73,7 +37,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,302 +4,72 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  nixConfig = {
-    extra-trusted-public-keys = [
-      "i-am-logger.cachix.org-1:wGCjEpWzIVhSWh0Pe+3VbIvecLaUIhjaWx5vjXzWUOE="
-    ];
-    extra-substituters = [
-      "https://i-am-logger.cachix.org"
-    ];
-    extra-sandbox-paths = [
-      "/tmp/ccache"
-    ];
-  };
-
-  outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , nixos-generators
-    , ...
-    } @ inputs:
+  outputs = { nixpkgs, flake-utils, ... }:
     let
-      localSystem = "x86_64-linux";
-      pkgsLocal = import nixpkgs { system = localSystem; };
+      # Target architecture (what we're building FOR)
+      targetSystem = "aarch64-linux";
 
-      aarch64System = "aarch64-linux";
+      # CIX Sky1 SoC (overlays, module, configurations)
+      cixSky1 = import ./modules/soc-cix-sky1 { inherit nixpkgs; };
 
-      # Native aarch64 packages with CIX CD8180/CD8160 overlays
-      pkgsNative = import nixpkgs {
-        system = aarch64System;
-        overlays = [ self.overlays.default ];
+      # Helper functions
+      lib = import ./lib {
+        inherit nixpkgs targetSystem;
+        socOverlays = cixSky1.overlays;
       };
 
-      # Cross-compiled packages with CIX CD8180/CD8160 overlays
-      pkgsCross = import nixpkgs {
-        inherit localSystem;
-        crossSystem = aarch64System;
-        overlays = [ self.overlays.default ];
+      # Orange Pi 6 Plus board
+      orangepi6plus = import ./modules/boards/orangepi6plus {
+        inherit nixpkgs;
+        socOverlays = cixSky1.overlays;
       };
     in
     {
-      overlays = {
-        # Vendor kernels for CIX CD8180/CD8160
-        cixSky1Kernels = final: prev: (import ./pkgs/kernel { pkgs = prev; });
-
-        # CIX CD8180/CD8160 drivers and firmware (SoC-specific)
-        cixSky1Drivers = final: prev: {
-          cix-gpu-umd = final.callPackage ./pkgs/drivers/gpu { };
-          cix-npu-umd = final.callPackage ./pkgs/drivers/npu { };
-          cix-isp-umd = final.callPackage ./pkgs/drivers/isp { };
-          cix-vpu-firmware = (final.callPackage ./pkgs/drivers/vpu { }).vpu-firmware;
-          cix-firmware = final.callPackage ./pkgs/firmware { };
-          cix-tools = final.callPackage ./pkgs/cix-tools { };
-        };
-
-        # Combined overlay for convenience
-        default = final: prev:
-          (self.overlays.cixSky1Kernels final prev) //
-          (self.overlays.cixSky1Drivers final prev);
-      };
+      overlays.default = cixSky1.overlays.default;
 
       nixosModules = {
-        # Board-specific modules
-        orangepi6plus = {
-          default = ./modules/boards/orangepi6plus;
-          sdImage = ./modules/sd-image;
-          netboot = ./modules/boards/orangepi6plus/netboot.nix;
-        };
-
-        # Board module with overlay (for user configurations)
-        boards = {
-          orangepi6plus = { config, pkgs, lib, ... }: {
-            imports = [ ./modules/boards/orangepi6plus ];
-            nixpkgs.overlays = [ self.overlays.default ];
-            nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-              "cix-gpu-umd"
-              "cix-npu-umd"
-              "cix-isp-umd"
-              "cix-vpu-firmware"
-              "cix-firmware"
-              "cix-tools"
-            ];
-          };
-        };
-
-        kernel = {
-          vendor = import ./pkgs/kernel/vendor.nix;
-          mainline = import ./pkgs/kernel/mainline.nix;
-        };
-
-        drivers = {
-          gpu = import ./pkgs/drivers/gpu;
-          npu = import ./pkgs/drivers/npu;
-          isp = import ./pkgs/drivers/isp;
-          vpu = import ./pkgs/drivers/vpu;
-        };
-
-        firmware = import ./pkgs/firmware;
+        cix-sky1 = cixSky1.module;
+        orangepi6plus = orangepi6plus.module;
       };
 
-      nixosConfigurations = {
-        orangepi6plus = nixpkgs.lib.nixosSystem {
-          system = aarch64System;
-          specialArgs = {
-            cixSky1 = {
-              inherit nixpkgs;
-              pkgsKernel = pkgsNative;
-            };
-          };
-          modules = [
-            ./modules/configuration.nix
-            self.nixosModules.boards.orangepi6plus
-            self.nixosModules.orangepi6plus.sdImage
-            {
-              networking.hostName = "orangepi6plus";
-            }
-          ];
-        };
-
-        orangepi6plus-cross = nixpkgs.lib.nixosSystem {
-          specialArgs = {
-            cixSky1 = {
-              inherit nixpkgs;
-              pkgsKernel = pkgsCross;
-            };
-          };
-          modules = [
-            ./modules/configuration.nix
-            self.nixosModules.boards.orangepi6plus
-            self.nixosModules.orangepi6plus.sdImage
-            {
-              networking.hostName = "orangepi6plus";
-              nixpkgs.buildPlatform = localSystem;
-              nixpkgs.hostPlatform = aarch64System;
-            }
-          ];
-        };
-
-        orangepi6plus-netboot = nixpkgs.lib.nixosSystem {
-          system = aarch64System;
-          specialArgs = {
-            cixSky1 = {
-              inherit nixpkgs;
-              pkgsKernel = pkgsNative;
-            };
-          };
-          modules = [
-            ./modules/configuration.nix
-            self.nixosModules.boards.orangepi6plus
-            self.nixosModules.orangepi6plus.netboot
-            {
-              networking.hostName = "orangepi6plus";
-            }
-          ];
-        };
-
-        orangepi6plus-netboot-cross = nixpkgs.lib.nixosSystem {
-          system = localSystem;
-          specialArgs = {
-            cixSky1 = {
-              inherit nixpkgs;
-              pkgsKernel = pkgsCross;
-            };
-          };
-          modules = [
-            ./modules/configuration.nix
-            self.nixosModules.boards.orangepi6plus
-            self.nixosModules.orangepi6plus.netboot
-            {
-              networking.hostName = "orangepi6plus";
-              nixpkgs.buildPlatform = localSystem;
-              nixpkgs.hostPlatform = aarch64System;
-            }
-          ];
-        };
-      };
+      nixosConfigurations = orangepi6plus.configurations;
     }
     // flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
+      let
+        pkgs = import nixpkgs { inherit system; };
 
-      # Package sets with unfree allowed for firmware/tools
-      pkgsNativeUnfree = import nixpkgs {
-        system = aarch64System;
-        overlays = [ self.overlays.default ];
-        config.allowUnfree = true;
-      };
-
-      pkgsCrossUnfree = import nixpkgs {
-        localSystem = system;
-        crossSystem = aarch64System;
-        overlays = [ self.overlays.default ];
-        config.allowUnfree = true;
-      };
-    in
-    {
-      packages = {
-        # SoC-level packages (CIX Sky1 - works on any Sky1 board)
-        kernel = self.nixosConfigurations.orangepi6plus.config.boot.kernelPackages.kernel;
-        kernel-cross = self.nixosConfigurations.orangepi6plus-cross.config.boot.kernelPackages.kernel;
-
-        drivers = self.nixosConfigurations.orangepi6plus.config.system.build.modulesClosure;
-        drivers-cross = self.nixosConfigurations.orangepi6plus-cross.config.system.build.modulesClosure;
-
-        firmware = pkgsNativeUnfree.cix-firmware;
-        firmware-cross = pkgsCrossUnfree.cix-firmware;
-
-        tools = pkgsNativeUnfree.cix-tools;
-        tools-cross = pkgsCrossUnfree.cix-tools;
-
-        # Board-specific packages (Orange Pi 6 Plus)
-        # Naming: boards-orangepi6plus-{type}[-cross]
-        boards-orangepi6plus-sdImage = self.nixosConfigurations.orangepi6plus.config.system.build.sdImage;
-        boards-orangepi6plus-sdImage-cross = self.nixosConfigurations.orangepi6plus-cross.config.system.build.sdImage;
-
-        boards-orangepi6plus-netboot = pkgs.runCommand "netboot-orangepi6plus" { } ''
-          mkdir -p $out
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot.config.system.build.kernel}/Image $out/kernel
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot.config.system.build.netbootRamdisk}/initrd $out/initrd
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot.config.system.build.netbootIpxeScript}/netboot.ipxe $out/netboot.ipxe
-        '';
-
-        boards-orangepi6plus-netboot-cross = pkgs.runCommand "netboot-orangepi6plus-cross" { } ''
-          mkdir -p $out
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot-cross.config.system.build.kernel}/Image $out/kernel
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot-cross.config.system.build.netbootRamdisk}/initrd $out/initrd
-          ln -s ${self.nixosConfigurations.orangepi6plus-netboot-cross.config.system.build.netbootIpxeScript}/netboot.ipxe $out/netboot.ipxe
-        '';
-
-        # Board tools: orangepi-config + wiringop combined
-        boards-orangepi6plus-tools = pkgs.symlinkJoin {
-          name = "orangepi6plus-tools";
-          paths = [
-            (pkgsNativeUnfree.callPackage ./pkgs/orangepi-config { })
-            (pkgsNativeUnfree.callPackage ./pkgs/wiringop { })
-          ];
+        # Native target packages (aarch64 native)
+        pkgsNativeUnfree = import nixpkgs {
+          system = targetSystem;
+          overlays = [ cixSky1.overlays.default ];
+          config.allowUnfree = true;
         };
 
-        boards-orangepi6plus-tools-cross = pkgs.symlinkJoin {
-          name = "orangepi6plus-tools-cross";
-          paths = [
-            (pkgsCrossUnfree.callPackage ./pkgs/orangepi-config { })
-            (pkgsCrossUnfree.callPackage ./pkgs/wiringop { })
-          ];
+        # Cross-compiled packages (for devShells)
+        pkgsCrossUnfree = import nixpkgs {
+          localSystem = system;
+          crossSystem = targetSystem;
+          overlays = [ cixSky1.overlays.default ];
+          config.allowUnfree = true;
         };
-      };
 
-      devShells.default = pkgs.mkShell {
-        name = "nixos-cix-cd8180-dev";
-        packages = with pkgs; [
-          git
-          cachix
-          nix-prefetch-github
-          nixpkgs-fmt
-        ];
-        shellHook = ''
-          echo "NixOS CIX CD8180/CD8160 (Sky1) Development Environment"
-          echo ""
-          echo "Available commands:"
-          echo "  nix flake check       - Check flake"
-          echo "  nixpkgs-fmt --check . - Check formatting"
-          echo "  nixpkgs-fmt .         - Format all .nix files"
-          echo "  nix build .#sdImage   - Build SD image"
-          echo "  cachix push           - Push to cache"
-        '';
-      };
+        # SoC packages (kernel, drivers, firmware, tools) for THIS system
+        socPackages = lib.mkSocPackages {
+          soc = cixSky1.configurations;
+          inherit pkgsNativeUnfree pkgsCrossUnfree;
+        };
 
-      devShells.kernel = pkgs.mkShell {
-        name = "kernel-build-env";
-        packages = with pkgs; [
-          pkg-config
-          ncurses
-          pkgsCross.gccStdenv.cc
-          gcc
-          bc
-          bison
-          flex
-          openssl
-          perl
-          python3
-          dtc
-        ] ++ pkgs.linux.nativeBuildInputs;
+        # Board packages for THIS system
+        orangepi6plusPackages = lib.mkBoardPackages {
+          inherit pkgs pkgsNativeUnfree pkgsCrossUnfree;
+          board = orangepi6plus;
+        };
+      in
+      {
+        packages = socPackages // orangepi6plusPackages;
 
-        shellHook = ''
-          export CROSS_COMPILE=aarch64-unknown-linux-gnu-
-          export ARCH=arm64
-          export PKG_CONFIG_PATH="${pkgs.ncurses.dev}/lib/pkgconfig:"
-          echo "Kernel development environment for CIX CD8180/CD8160"
-          echo "ARCH=$ARCH"
-          echo "CROSS_COMPILE=$CROSS_COMPILE"
-        '';
-      };
-    });
+        devShells = import ./devshells.nix { inherit pkgs pkgsCrossUnfree; };
+      });
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,43 @@
+# Helper functions for flake
+{ nixpkgs, socOverlays, targetSystem }:
+
+let
+  unfree = import ./unfree.nix { lib = nixpkgs.lib; };
+in
+{
+  # Re-export unfree utilities
+  inherit (unfree) allowCixSky1Unfree;
+
+  # Generate packages for a board (using board's mkPackages function)
+  # args: { pkgs, pkgsNativeUnfree, pkgsCrossUnfree, board }
+  # pkgs: Base packages for current system (used for runCommand, symlinkJoin, etc.)
+  # pkgsNativeUnfree: Native target packages with unfree allowed
+  # pkgsCrossUnfree: Cross-compiled packages with unfree allowed
+  # board: Board configuration (must have mkPackages function)
+  # Returns: { packages }
+  mkBoardPackages = { pkgs, pkgsNativeUnfree, pkgsCrossUnfree, board }:
+    board.mkPackages { inherit pkgs pkgsNativeUnfree pkgsCrossUnfree; };
+
+  # Generate SoC packages (kernel, drivers, firmware, tools) for a specific system
+  # args: { soc, pkgsNativeUnfree, pkgsCrossUnfree }
+  # soc: SoC configuration from configurations.nix (has .native and .cross)
+  # pkgsNativeUnfree: Native target packages with unfree allowed
+  # pkgsCrossUnfree: Cross-compiled packages with unfree allowed
+  # Returns: { kernel, kernel-cross, drivers, drivers-cross, firmware, firmware-cross, tools, tools-cross }
+  mkSocPackages = { soc, pkgsNativeUnfree, pkgsCrossUnfree }:
+    {
+      # Kernel and drivers (from SoC configurations)
+      kernel = soc.native.config.boot.kernelPackages.kernel;
+      kernel-cross = soc.cross.config.boot.kernelPackages.kernel;
+
+      drivers = soc.native.config.system.build.modulesClosure;
+      drivers-cross = soc.cross.config.system.build.modulesClosure;
+
+      # Firmware and tools (from overlays)
+      firmware = pkgsNativeUnfree.cix-firmware;
+      firmware-cross = pkgsCrossUnfree.cix-firmware;
+
+      tools = pkgsNativeUnfree.cix-tools;
+      tools-cross = pkgsCrossUnfree.cix-tools;
+    };
+}

--- a/lib/unfree.nix
+++ b/lib/unfree.nix
@@ -1,0 +1,16 @@
+# Unfree package predicates for CIX Sky1 SoC
+# This allows proprietary drivers and firmware to be installed
+{ lib }:
+
+{
+  # Predicate for allowing CIX Sky1 proprietary packages
+  # Used in nixosModules and configurations
+  allowCixSky1Unfree = pkg: builtins.elem (lib.getName pkg) [
+    "cix-gpu-umd" # Mali-G610 MP4 GPU userspace drivers
+    "cix-npu-umd" # 28.8 TOPS NPU userspace drivers
+    "cix-isp-umd" # Image Signal Processor userspace drivers
+    "cix-vpu-firmware" # Video Processing Unit firmware
+    "cix-firmware" # General SoC firmware
+    "cix-tools" # SoC tools (i3ctransfer, pmtool)
+  ];
+}

--- a/modules/boards/orangepi6plus/configurations.nix
+++ b/modules/boards/orangepi6plus/configurations.nix
@@ -1,0 +1,153 @@
+# NixOS configurations and module for Orange Pi 6 Plus
+# Provides nixosModule, SD image, netboot, and cross-compilation variants
+{ nixpkgs, socOverlays, pkgs ? null, pkgsNativeUnfree ? null, pkgsCrossUnfree ? null, ... }:
+
+let
+  localSystem = "x86_64-linux";
+  aarch64System = "aarch64-linux";
+
+  # Native aarch64 packages
+  pkgsNative = import nixpkgs {
+    system = aarch64System;
+    overlays = [ socOverlays.default ];
+  };
+
+  # Cross-compiled packages
+  pkgsCross = import nixpkgs {
+    inherit localSystem;
+    crossSystem = aarch64System;
+    overlays = [ socOverlays.default ];
+  };
+
+  # Import unfree predicate from lib
+  unfree = import ../../../lib/unfree.nix { lib = nixpkgs.lib; };
+  allowUnfreePredicate = unfree.allowCixSky1Unfree;
+
+  # Helper to create netboot package
+  mkNetbootPackage = name: cfg: pkgs.runCommand name { } ''
+    mkdir -p $out
+    ln -s ${cfg.config.system.build.kernel}/Image $out/kernel
+    ln -s ${cfg.config.system.build.netbootRamdisk}/initrd $out/initrd
+    ln -s ${cfg.config.system.build.netbootIpxeScript}/netboot.ipxe $out/netboot.ipxe
+  '';
+in
+rec {
+  # User-facing NixOS module
+  module = import ./module.nix socOverlays;
+
+  # Build configurations
+  configurations = {
+    # Native aarch64 build with SD image
+    orangepi6plus = nixpkgs.lib.nixosSystem {
+      system = aarch64System;
+      specialArgs = {
+        cixSky1 = {
+          inherit nixpkgs;
+          pkgsKernel = pkgsNative;
+        };
+      };
+      modules = [
+        ../../configuration.nix
+        ./hardware.nix
+        ../../sd-image
+        {
+          nixpkgs.overlays = [ socOverlays.default ];
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+          networking.hostName = "orangepi6plus";
+        }
+      ];
+    };
+
+    # Cross-compiled from x86_64 with SD image
+    orangepi6plus-cross = nixpkgs.lib.nixosSystem {
+      specialArgs = {
+        cixSky1 = {
+          inherit nixpkgs;
+          pkgsKernel = pkgsCross;
+        };
+      };
+      modules = [
+        ../../configuration.nix
+        ./hardware.nix
+        ../../sd-image
+        {
+          nixpkgs.overlays = [ socOverlays.default ];
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+          networking.hostName = "orangepi6plus";
+          nixpkgs.buildPlatform = localSystem;
+          nixpkgs.hostPlatform = aarch64System;
+        }
+      ];
+    };
+
+    # Native aarch64 netboot
+    orangepi6plus-netboot = nixpkgs.lib.nixosSystem {
+      system = aarch64System;
+      specialArgs = {
+        cixSky1 = {
+          inherit nixpkgs;
+          pkgsKernel = pkgsNative;
+        };
+      };
+      modules = [
+        ../../configuration.nix
+        ./hardware.nix
+        ./netboot.nix
+        {
+          nixpkgs.overlays = [ socOverlays.default ];
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+          networking.hostName = "orangepi6plus";
+        }
+      ];
+    };
+
+    # Cross-compiled netboot
+    orangepi6plus-netboot-cross = nixpkgs.lib.nixosSystem {
+      system = localSystem;
+      specialArgs = {
+        cixSky1 = {
+          inherit nixpkgs;
+          pkgsKernel = pkgsCross;
+        };
+      };
+      modules = [
+        ../../configuration.nix
+        ./hardware.nix
+        ./netboot.nix
+        {
+          nixpkgs.overlays = [ socOverlays.default ];
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+          networking.hostName = "orangepi6plus";
+          nixpkgs.buildPlatform = localSystem;
+          nixpkgs.hostPlatform = aarch64System;
+        }
+      ];
+    };
+  };
+
+  # Packages (only if pkgs is provided)
+  packages =
+    if pkgs != null then {
+      orangepi6plus-sdImage = configurations.orangepi6plus.config.system.build.sdImage;
+      orangepi6plus-sdImage-cross = configurations.orangepi6plus-cross.config.system.build.sdImage;
+
+      orangepi6plus-netboot = mkNetbootPackage "netboot-orangepi6plus" configurations.orangepi6plus-netboot;
+      orangepi6plus-netboot-cross = mkNetbootPackage "netboot-orangepi6plus-cross" configurations.orangepi6plus-netboot-cross;
+
+      orangepi6plus-tools = pkgs.symlinkJoin {
+        name = "orangepi6plus-tools";
+        paths = [
+          (pkgsNativeUnfree.callPackage ../../../pkgs/orangepi-config { })
+          (pkgsNativeUnfree.callPackage ../../../pkgs/wiringop { })
+        ];
+      };
+
+      orangepi6plus-tools-cross = pkgs.symlinkJoin {
+        name = "orangepi6plus-tools-cross";
+        paths = [
+          (pkgsCrossUnfree.callPackage ../../../pkgs/orangepi-config { })
+          (pkgsCrossUnfree.callPackage ../../../pkgs/wiringop { })
+        ];
+      };
+    } else { };
+}

--- a/modules/boards/orangepi6plus/default.nix
+++ b/modules/boards/orangepi6plus/default.nix
@@ -1,39 +1,22 @@
-# Orange Pi 6 Plus board-specific configuration
-# Board uses CIX Sky1 SoC (CD8180/CD8160) - see soc/sky1.nix for SoC config
-{ config, pkgs, lib, ... }:
+# Orange Pi 6 Plus board - entry point
+# Returns: { module, configurations, packages, mkPackages }
+{ nixpkgs ? null, socOverlays ? null, pkgs ? null, pkgsNativeUnfree ? null, pkgsCrossUnfree ? null }:
 
+let
+  boardConfig =
+    if nixpkgs != null && socOverlays != null then
+      import ./configurations.nix { inherit nixpkgs socOverlays pkgs pkgsNativeUnfree pkgsCrossUnfree; }
+    else
+      { module = null; configurations = { }; packages = { }; };
+in
 {
-  imports = [
-    ../../soc/sky1.nix # CIX Sky1 SoC base configuration
-  ];
+  module = boardConfig.module;
+  configurations = boardConfig.configurations;
+  packages = boardConfig.packages or { };
 
-  config = {
-    # Orange Pi specific packages
-    nixpkgs.overlays = [
-      (final: prev: {
-        orangepi-config = final.callPackage ../../../pkgs/orangepi-config { };
-        wiringop = final.callPackage ../../../pkgs/wiringop { };
-      })
-    ];
-
-    boot = {
-      # UEFI boot
-      loader = {
-        systemd-boot.enable = true;
-        efi.canTouchEfiVariables = true;
-      };
-
-      # Board-specific kernel parameters (serial console)
-      kernelParams = [
-        "console=ttyS2,1500000" # Orange Pi 6 Plus serial port
-        "console=tty1" # HDMI
-      ];
-    };
-
-    # Orange Pi board-specific tools (GPIO, hardware config)
-    environment.systemPackages = with pkgs; [
-      orangepi-config # Orange Pi hardware configuration tool
-      wiringop # Orange Pi GPIO library and tools
-    ];
-  };
+  # Function to regenerate packages with different pkgs
+  mkPackages = { pkgs, pkgsNativeUnfree, pkgsCrossUnfree }:
+    (import ./configurations.nix {
+      inherit nixpkgs socOverlays pkgs pkgsNativeUnfree pkgsCrossUnfree;
+    }).packages;
 }

--- a/modules/boards/orangepi6plus/hardware.nix
+++ b/modules/boards/orangepi6plus/hardware.nix
@@ -1,0 +1,39 @@
+# Orange Pi 6 Plus board-specific hardware configuration
+# Board uses CIX Sky1 SoC (CD8180/CD8160) - see soc-cix-sky1/module.nix for SoC config
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [
+    ../../soc-cix-sky1/module.nix # CIX Sky1 SoC base configuration
+  ];
+
+  config = {
+    # Orange Pi specific packages
+    nixpkgs.overlays = [
+      (final: prev: {
+        orangepi-config = final.callPackage ../../../pkgs/orangepi-config { };
+        wiringop = final.callPackage ../../../pkgs/wiringop { };
+      })
+    ];
+
+    boot = {
+      # UEFI boot
+      loader = {
+        systemd-boot.enable = true;
+        efi.canTouchEfiVariables = true;
+      };
+
+      # Board-specific kernel parameters (serial console)
+      kernelParams = [
+        "console=ttyS2,1500000" # Orange Pi 6 Plus serial port
+        "console=tty1" # HDMI
+      ];
+    };
+
+    # Orange Pi board-specific tools (GPIO, hardware config)
+    environment.systemPackages = with pkgs; [
+      orangepi-config # Orange Pi hardware configuration tool
+      wiringop # Orange Pi GPIO library and tools
+    ];
+  };
+}

--- a/modules/boards/orangepi6plus/module.nix
+++ b/modules/boards/orangepi6plus/module.nix
@@ -1,0 +1,15 @@
+# Orange Pi 6 Plus NixOS module
+# Includes board configuration + SoC overlays + unfree predicate
+socOverlays:
+
+{ config, pkgs, lib, ... }:
+let
+  unfree = import ../../../lib/unfree.nix { inherit lib; };
+in
+{
+  imports = [ ./hardware.nix ];
+
+  nixpkgs.overlays = [ socOverlays.default ];
+
+  nixpkgs.config.allowUnfreePredicate = unfree.allowCixSky1Unfree;
+}

--- a/modules/soc-cix-sky1/configurations.nix
+++ b/modules/soc-cix-sky1/configurations.nix
@@ -1,0 +1,76 @@
+# Sky1 SoC configuration
+# Used to build SoC-level packages (kernel, drivers) for all Sky1-based boards
+{ nixpkgs, socOverlays }:
+
+let
+  localSystem = "x86_64-linux";
+  targetSystem = "aarch64-linux";
+
+  # Native aarch64 packages
+  pkgsNative = import nixpkgs {
+    system = targetSystem;
+    overlays = [ socOverlays.default ];
+  };
+
+  # Cross-compiled packages
+  pkgsCross = import nixpkgs {
+    inherit localSystem;
+    crossSystem = targetSystem;
+    overlays = [ socOverlays.default ];
+  };
+
+  # Import unfree predicate from lib
+  unfree = import ../../lib/unfree.nix { lib = nixpkgs.lib; };
+  allowUnfreePredicate = unfree.allowCixSky1Unfree;
+in
+rec {
+  # Native aarch64 configuration
+  native = nixpkgs.lib.nixosSystem {
+    system = targetSystem;
+    specialArgs = {
+      cixSky1 = {
+        inherit nixpkgs;
+        pkgsKernel = pkgsNative;
+      };
+    };
+    modules = [
+      ../configuration.nix
+      ./module.nix
+      {
+        nixpkgs.overlays = [ socOverlays.default ];
+        nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+        networking.hostName = "sky1";
+        # Minimal system for building SoC packages
+        boot.loader.grub.enable = nixpkgs.lib.mkForce false;
+        fileSystems."/" = nixpkgs.lib.mkForce { device = "none"; fsType = "tmpfs"; };
+        fileSystems."/boot" = nixpkgs.lib.mkForce { device = "none"; fsType = "tmpfs"; };
+      }
+    ];
+  };
+
+  # Cross-compiled configuration
+  cross = nixpkgs.lib.nixosSystem {
+    system = localSystem;
+    specialArgs = {
+      cixSky1 = {
+        inherit nixpkgs;
+        pkgsKernel = pkgsCross;
+      };
+    };
+    modules = [
+      ../configuration.nix
+      ./module.nix
+      {
+        nixpkgs.overlays = [ socOverlays.default ];
+        nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+        networking.hostName = "sky1";
+        nixpkgs.buildPlatform = localSystem;
+        nixpkgs.hostPlatform = targetSystem;
+        # Minimal system for building SoC packages
+        boot.loader.grub.enable = nixpkgs.lib.mkForce false;
+        fileSystems."/" = nixpkgs.lib.mkForce { device = "none"; fsType = "tmpfs"; };
+        fileSystems."/boot" = nixpkgs.lib.mkForce { device = "none"; fsType = "tmpfs"; };
+      }
+    ];
+  };
+}

--- a/modules/soc-cix-sky1/default.nix
+++ b/modules/soc-cix-sky1/default.nix
@@ -1,0 +1,25 @@
+# CIX Sky1 SoC - entry point
+# Returns: { overlays, module, configurations }
+{ nixpkgs ? null, socOverlays ? null }:
+
+let
+  # Import overlays first (they're always available)
+  overlays = import ./overlays.nix;
+
+  # If nixpkgs is provided, also return module and configurations
+  hasNixpkgs = nixpkgs != null;
+
+  # Use provided overlays or default to local ones
+  actualOverlays = if socOverlays != null then socOverlays else overlays;
+in
+{
+  inherit overlays;
+
+  module = import ./module.nix;
+
+  configurations =
+    if hasNixpkgs then
+      import ./configurations.nix { inherit nixpkgs; socOverlays = actualOverlays; }
+    else
+      null;
+}

--- a/modules/soc-cix-sky1/module.nix
+++ b/modules/soc-cix-sky1/module.nix
@@ -86,12 +86,12 @@
   nixpkgs.hostPlatform = "aarch64-linux";
 
   # Default filesystem configuration
-  fileSystems."/" = {
+  fileSystems."/" = lib.mkDefault {
     device = "/dev/disk/by-label/NIXOS_SD";
     fsType = "ext4";
   };
 
-  fileSystems."/boot" = {
+  fileSystems."/boot" = lib.mkDefault {
     device = "/dev/disk/by-label/BOOT";
     fsType = "vfat";
   };

--- a/modules/soc-cix-sky1/overlays.nix
+++ b/modules/soc-cix-sky1/overlays.nix
@@ -1,0 +1,21 @@
+# CIX CD8180/CD8160 SoC overlays
+# Kernels, drivers, firmware, and tools
+let
+  kernels = final: prev: (import ../../pkgs/kernel { pkgs = prev; });
+
+  drivers = final: prev: {
+    cix-gpu-umd = final.callPackage ../../pkgs/drivers/gpu { };
+    cix-npu-umd = final.callPackage ../../pkgs/drivers/npu { };
+    cix-isp-umd = final.callPackage ../../pkgs/drivers/isp { };
+    cix-vpu-firmware = (final.callPackage ../../pkgs/drivers/vpu { }).vpu-firmware;
+    cix-firmware = final.callPackage ../../pkgs/firmware { };
+    cix-tools = final.callPackage ../../pkgs/cix-tools { };
+  };
+in
+{
+  inherit kernels drivers;
+
+  default = final: prev:
+    kernels final prev //
+    drivers final prev;
+}

--- a/nix.conf
+++ b/nix.conf
@@ -1,0 +1,3 @@
+extra-trusted-public-keys = i-am-logger.cachix.org-1:wGCjEpWzIVhSWh0Pe+3VbIvecLaUIhjaWx5vjXzWUOE=
+extra-substituters = https://i-am-logger.cachix.org
+extra-sandbox-paths = /tmp/ccache

--- a/pkgs/kernel/README.md
+++ b/pkgs/kernel/README.md
@@ -24,7 +24,7 @@ The Orange Pi 6 Plus board module uses the vendor kernel by default for full har
 
 ### Default: Vendor Kernel
 
-The `nixosModules.boards.orangepi6plus` module automatically configures:
+The board module automatically configures:
 
 ```nix
 boot.kernelPackages = pkgs.cixSky1VendorKernelPackages;


### PR DESCRIPTION
- Reduce flake.nix from 269 to 75 lines
- Separate SoC (modules/soc-cix-sky1/) from board (modules/boards/orangepi6plus/)
- Extract helper functions to lib/ (mkSocPackages, mkBoardPackages)
- Extract devshells.nix and nix.conf from flake
- Add default.nix entry points for SoC and boards
- Remove unused dependencies (self, nixos-generators)
- Rename package outputs: boards-orangepi6plus-* -> orangepi6plus-*

Code quality improvements:
- Centralize unfree predicate in lib/unfree.nix (eliminate duplication)
- Optimize mkSocPackages to accept pkgs as parameters (no duplicate evaluations)
- Clean up function signatures (remove unused parameters)
- Fix mkForce usage in cross-compilation config

Update documentation and CI/CD with new structure and package names.